### PR TITLE
Move illuminate and symfony dependencies to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
         "MIT"
     ],
     "require": {
-        "php": ">=5.3.7",
+        "php": ">=5.3.7"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*",
+        "mockery/mockery": "0.8.0",
         "illuminate/support": "4.0.x",
         "psr/log": "~1.0",
         "illuminate/filesystem": "4.0.x",
         "symfony/finder": "2.3.*"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "3.7.*",
-        "mockery/mockery": "dev-master@dev"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
This is only required during development, for end user the Laravel installation
would already the requirement installed, this also prevent error such as
laravel/framework#1524

Signed-off-by: crynobone crynobone@gmail.com
