### PR TITLE
Default to english when no language found

### DIFF
--- a/src/filters.php
+++ b/src/filters.php
@@ -3,6 +3,9 @@
 Route::filter('logviewer.logs', function()
 {
     $logs = array();
+    if( ! Lang::has('logviewer::logviewer.sapi')){
+        App::setLocale('en');
+    }
     foreach (Lang::get('logviewer::logviewer.sapi') as $sapi => $human)
     {
         $logs[$sapi]['sapi'] = $human;


### PR DESCRIPTION
I know I can add extra languages, but this check just defaults to 'en'. This prevents errors on the foreach.

But I actually think that those SAPI value's should not be in a language file, but in the config. (What if you want to add extra values?)
