### PR TITLE
Fix for Bootstrap 3.0 users.

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -130,6 +130,8 @@ Route::group(array('before' => $filters['before'], 'after' => $filters['after'])
 
             $levels = $logviewer->getLevels();
             
+            Config::set('view.pagination', 'pagination::slider');//Fix for Twitter bootstrap 3 users
+            
             $page = Paginator::make($log, count($log), Config::get('logviewer::per_page', 10));
             
             return View::make(Config::get('logviewer::view'))


### PR DESCRIPTION
When you use Bootstrap 3.0 you need to set the config view.pagination to pagination::slider-3. This fixes the page navigation in Bootstrap 3.0 but disables the navigation feature for Bootstrap 2.3.2. This commit allows you to use both.
