### PR TITLE
Revert "Fix for Bootstrap 3.0 users."

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -130,8 +130,6 @@ Route::group(array('before' => $filters['before'], 'after' => $filters['after'])
 
             $levels = $logviewer->getLevels();
             
-            Config::set('view.pagination', 'pagination::slider');//Fix for Twitter bootstrap 3 users
-            
             $page = Paginator::make($log, count($log), Config::get('logviewer::per_page', 10));
             
             return View::make(Config::get('logviewer::view'))


### PR DESCRIPTION
This reverts commit 1176ded6f9f92ee04962c7a1790404360beeef30.

This fix doesn't work and is a stupid idea. It brakes pagination for the whole of any Laravel application...

If the user wants Bootstrap 3 compatibility, then they should change the app/config/view.php in their application.
