### PR TITLE
Update routes.php

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -130,9 +130,17 @@ Route::group(array('before' => $filters['before'], 'after' => $filters['after'])
 
             $levels = $logviewer->getLevels();
             
-            Config::set('view.pagination', 'pagination::slider');//Fix for Twitter bootstrap 3 users
-            
-            $page = Paginator::make($log, count($log), Config::get('logviewer::per_page', 10));
+            $tmpConfigViewPagination = Config::get('view.pagination');
+            if($tmpConfigViewPagination == 'pagination::slider-3')
+            {
+                Config::set('view.pagination', 'pagination::slider');//Fix for Twitter bootstrap 3 users
+                $page = Paginator::make($log, count($log), Config::get('logviewer::per_page', 10));
+                Config::set('view.pagination', 'pagination::slider-3');
+            }
+            else
+            {
+                $page = Paginator::make($log, count($log), Config::get('logviewer::per_page', 10));
+            }
             
             return View::make(Config::get('logviewer::view'))
                        ->with('paginator', $page)


### PR DESCRIPTION
Because the previous commit broke an installation I've changed the commit. If you're using bootstrap 3.0 you've configured the view.pagination pagination::slider-3. This will break the navigation for bootstrap 3.0 users. To fix this the view needs to be set to pagination::slider. This was done in the previous commit however it set the fix for all installations. Now it only changes the view.pagination if you've configure pagination::slider-3.

NOTE 1: It assumes that you're using the default slider-3 file.
NOTE 2: It sets the original configuration back when the paginator is created.
