### PR TITLE
Symfony fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=5.3.7",
         "illuminate/support": "~4",
         "illuminate/filesystem": "~4",
-        "symfony/finder": ">=2.3,<=2.4",
+        "symfony/finder": "2.3.*|2.4.*",
         "psr/log": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Finally a correct fix for symfony components in composer. The last fix meant that only 2.4.0 could be used from the 2.4.\* branch, which will be an issue when 2.4.1 is released.
